### PR TITLE
invalidate connection handle rather than closing database inside cleanUp...

### DIFF
--- a/orient-ra-api/src/main/java/org/ops4j/orient/adapter/api/OrientDatabaseConnection.java
+++ b/orient-ra-api/src/main/java/org/ops4j/orient/adapter/api/OrientDatabaseConnection.java
@@ -30,9 +30,8 @@ import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
  *
  */
 public interface OrientDatabaseConnection extends Closeable {
-
-    ODatabaseDocumentTx document();
-    OObjectDatabaseTx object();
-    OGraphDatabase graph();
+    ODatabaseDocumentTx document() throws OrientDatabaseConnectionInvalidException;
+    OObjectDatabaseTx object() throws OrientDatabaseConnectionInvalidException;
+    OGraphDatabase graph() throws OrientDatabaseConnectionInvalidException;
     void close();
 }

--- a/orient-ra-api/src/main/java/org/ops4j/orient/adapter/api/OrientDatabaseConnectionInvalidException.java
+++ b/orient-ra-api/src/main/java/org/ops4j/orient/adapter/api/OrientDatabaseConnectionInvalidException.java
@@ -1,0 +1,10 @@
+package org.ops4j.orient.adapter.api;
+
+/**
+ * @author Markus Menner
+ */
+public class OrientDatabaseConnectionInvalidException extends Exception {
+	public OrientDatabaseConnectionInvalidException() {
+		super("connection has already been closed");
+	}
+}

--- a/orient-ra/src/main/java/org/ops4j/orient/adapter/impl/OrientDatabaseConnectionImpl.java
+++ b/orient-ra/src/main/java/org/ops4j/orient/adapter/impl/OrientDatabaseConnectionImpl.java
@@ -19,6 +19,7 @@
 package org.ops4j.orient.adapter.impl;
 
 import org.ops4j.orient.adapter.api.OrientDatabaseConnection;
+import org.ops4j.orient.adapter.api.OrientDatabaseConnectionInvalidException;
 
 import com.orientechnologies.orient.core.db.ODatabaseComplex;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
@@ -31,9 +32,9 @@ import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
  *
  */
 public class OrientDatabaseConnectionImpl implements OrientDatabaseConnection {
-
     private OrientManagedConnectionImpl mc;
     private ODatabaseComplex<?> db;
+		private boolean valid = true;
 
     public OrientDatabaseConnectionImpl(ODatabaseComplex<?> db, OrientManagedConnectionImpl mc) {
         this.db = db;
@@ -41,22 +42,39 @@ public class OrientDatabaseConnectionImpl implements OrientDatabaseConnection {
     }
 
     @Override
-    public ODatabaseDocumentTx document() {
+    public ODatabaseDocumentTx document() throws OrientDatabaseConnectionInvalidException {
+	      checkValidity();
         return (ODatabaseDocumentTx) db;
     }
 
     @Override
-    public OObjectDatabaseTx object() {
+    public OObjectDatabaseTx object() throws OrientDatabaseConnectionInvalidException {
+	      checkValidity();
         return (OObjectDatabaseTx) db;
     }
 
     @Override
-    public OGraphDatabase graph() {
+    public OGraphDatabase graph() throws OrientDatabaseConnectionInvalidException {
+	      checkValidity();
         return (OGraphDatabase) db;
     }
 
     @Override
     public void close() {
         mc.close();
-    }    
+    }
+
+		protected synchronized void setValid(boolean valid) {
+				this.valid = valid;
+		}
+
+		protected synchronized boolean isValid() {
+				return valid;
+		}
+
+		private void checkValidity() throws OrientDatabaseConnectionInvalidException {
+			if (!isValid()) {
+				throw new OrientDatabaseConnectionInvalidException();
+			}
+		}
 }

--- a/orient-ra/src/main/java/org/ops4j/orient/adapter/impl/OrientManagedConnectionImpl.java
+++ b/orient-ra/src/main/java/org/ops4j/orient/adapter/impl/OrientManagedConnectionImpl.java
@@ -165,7 +165,8 @@ public class OrientManagedConnectionImpl implements ManagedConnection, Closeable
     @Override
     public void cleanup() throws ResourceException {
         log.debug("cleanup()");
-        closeDatabase();
+	      this.connection.setValid(false);
+	      this.connection = null;
     }
 
     @Override

--- a/orient-samples/orient-sample1/src/main/java/org/ops4j/orient/sample1/OrientClient.java
+++ b/orient-samples/orient-sample1/src/main/java/org/ops4j/orient/sample1/OrientClient.java
@@ -24,6 +24,7 @@ import javax.ejb.Startup;
 import javax.inject.Inject;
 
 import org.ops4j.orient.adapter.api.OrientDatabaseConnection;
+import org.ops4j.orient.adapter.api.OrientDatabaseConnectionInvalidException;
 
 import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
 
@@ -35,13 +36,11 @@ import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
 @Singleton
 @Startup
 public class OrientClient {
-    
-
     @Inject
     private OrientDatabaseConnection connection;
     
     @PostConstruct
-    public void init() {
+    public void init() throws OrientDatabaseConnectionInvalidException {
         OObjectDatabaseTx db = connection.object();
         System.out.println("DB exists: "+ db.exists());
     }

--- a/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/DatabaseInitializer.java
+++ b/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/DatabaseInitializer.java
@@ -18,6 +18,8 @@
 
 package org.ops4j.orient.sample2;
 
+import org.ops4j.orient.adapter.api.OrientDatabaseConnectionInvalidException;
+
 import javax.annotation.PostConstruct;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
@@ -34,12 +36,11 @@ import javax.inject.Inject;
 @Startup
 @TransactionManagement(TransactionManagementType.BEAN)
 public class DatabaseInitializer {
-
     @Inject
     private LibraryService initializer;
 
     @PostConstruct
-    public void init() {
+    public void init() throws OrientDatabaseConnectionInvalidException {
         initializer.registerEntityClasses();
         initializer.createEntities();
     }

--- a/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/LibraryService.java
+++ b/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/LibraryService.java
@@ -28,6 +28,8 @@ import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
 
 import org.ops4j.orient.adapter.api.OrientDatabaseConnection;
+import org.ops4j.orient.adapter.api.OrientDatabaseConnectionInvalidException;
+
 import org.ops4j.orient.sample2.model.Author;
 import org.ops4j.orient.sample2.model.Book;
 import org.slf4j.Logger;
@@ -44,19 +46,18 @@ import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
  */
 @Stateless
 public class LibraryService {
-
     private static Logger log = LoggerFactory.getLogger(LibraryService.class);
 
     @Inject
     private OrientDatabaseConnection con;
 
     @TransactionAttribute(TransactionAttributeType.NEVER)
-    public void registerEntityClasses() {
+    public void registerEntityClasses() throws OrientDatabaseConnectionInvalidException {
         registerClass(Author.class);
         registerClass(Book.class);
     }
 
-    private <T> void registerClass(Class<T> klass) {
+    private <T> void registerClass(Class<T> klass) throws OrientDatabaseConnectionInvalidException {
         OEntityManager em = db(con).getEntityManager();
         OSchema schema = db(con).getMetadata().getSchema();
         if (schema.getClass(klass) == null) {
@@ -65,7 +66,7 @@ public class LibraryService {
         em.registerEntityClass(klass);
     }
 
-    public void createEntities() {
+    public void createEntities() throws OrientDatabaseConnectionInvalidException {
         Book hobbit = new Book();
         hobbit.setTitle("The Hobbit");
         db(con).save(hobbit);
@@ -75,7 +76,7 @@ public class LibraryService {
         db(con).save(timeMachine);
     }
 
-    public List<Book> findBooks() {
+    public List<Book> findBooks() throws OrientDatabaseConnectionInvalidException {
         log.info("finding books");
         return db(con).query(new OSQLSynchQuery<Book>("select from Book"));
     }

--- a/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/OrientDatabaseConnectionProducer.java
+++ b/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/OrientDatabaseConnectionProducer.java
@@ -27,6 +27,8 @@ import javax.resource.ResourceException;
 
 import org.ops4j.orient.adapter.api.OrientDatabaseConnection;
 import org.ops4j.orient.adapter.api.OrientDatabaseConnectionFactory;
+import org.ops4j.orient.adapter.api.OrientDatabaseConnectionInvalidException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +49,6 @@ import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
  */
 @ApplicationScoped
 public class OrientDatabaseConnectionProducer {
-
     private static Logger log = LoggerFactory.getLogger(OrientDatabaseConnectionProducer.class);
 
     @Resource(lookup = "orient/library")
@@ -70,7 +71,7 @@ public class OrientDatabaseConnectionProducer {
         connection.close();
     }
     
-    public static OObjectDatabaseTx db(OrientDatabaseConnection connection) {
+    public static OObjectDatabaseTx db(OrientDatabaseConnection connection) throws OrientDatabaseConnectionInvalidException {
         return connection.object();
     }
 }

--- a/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/web/LibraryController.java
+++ b/orient-samples/orient-sample2/src/main/java/org/ops4j/orient/sample2/web/LibraryController.java
@@ -28,6 +28,9 @@ import javax.inject.Named;
 import org.ops4j.orient.sample2.LibraryService;
 import org.ops4j.orient.sample2.model.Book;
 
+import org.ops4j.orient.adapter.api.OrientDatabaseConnectionInvalidException;
+
+
 
 /**
  * @author Harald Wellmann
@@ -43,7 +46,7 @@ public class LibraryController {
     private List<Book> books;
     
     @PostConstruct
-    public void init() {
+    public void init() throws OrientDatabaseConnectionInvalidException {
         books = libraryService.findBooks();
     }
 


### PR DESCRIPTION
Hi Harald,

As indicated, I have replaced the closeDatabase() call inside the cleanUp() method of OrientManagedConnectionImpl by calling a method that invalidates the connection handle (OrientDatabaseConnectionImpl).

From what I understood from the JCA Spec, a client needs to close the connection after using it, which in turn enables the app server to put the managed connection back into the pool. The database connection must not be closed, but its associated (client) connection handle needs to be invalidated (should throw an exception if used after a close).

As  OrientDatabaseConnectionImpl provides direct references to OObjectDatabaseTx, ODatabaseDocumentTx, etc., it would be even better to wrap these references into a decorator that provides means to be invalidated as well (i.e. a dynamic proxy). This way it would not be able to use the database handle any more after a close, which however is the case atm. Since there is no single interface that defines all methods of those connection types, I was reluctant to implement this type of proxy.
